### PR TITLE
CI: validate-only smoke test buildspec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,11 +41,15 @@ tf-validate-pipeline:
 
 # Native `terraform test` against the basic.tftest.hcl files. Mocked
 # providers, no real backend, no AWS calls — safe to run in CI on every push.
+# The prior `terraform init -backend=false` populates `.terraform/providers/`
+# (which `terraform test` requires); the TF_CLI_ARGS_init env var ensures any
+# internal `init` that `terraform test` performs per run block also skips the
+# real backend.
 tf-test-base:
-	@cd "$(TF_BASE_DIR)" && terraform init -backend=false && terraform test
+	@cd "$(TF_BASE_DIR)" && terraform init -backend=false && TF_CLI_ARGS_init="-backend=false" terraform test
 
 tf-test-pipeline:
-	@cd "$(TF_PIPELINE_DIR)" && terraform init -backend=false && terraform test
+	@cd "$(TF_PIPELINE_DIR)" && terraform init -backend=false && TF_CLI_ARGS_init="-backend=false" terraform test
 
 # One-shot smoke test for CI: fmt-check, validate, and run terraform tests
 # on both roots. No init against the real S3 backend, no apply.

--- a/Makefile
+++ b/Makefile
@@ -24,17 +24,32 @@ endef
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile tf-fmt tf-validate-base tf-validate-pipeline tf-init-base tf-plan-base tf-apply-base tf-workspace tf-init-pipeline tf-plan-pipeline tf-apply-pipeline
+.PHONY: help Makefile tf-fmt tf-fmt-check tf-validate-base tf-validate-pipeline tf-test-base tf-test-pipeline tf-smoke tf-init-base tf-plan-base tf-apply-base tf-workspace tf-init-pipeline tf-plan-pipeline tf-apply-pipeline
 
 # Terraform targets
 tf-fmt:
 	terraform fmt -recursive
+
+tf-fmt-check:
+	terraform fmt -check -recursive
 
 tf-validate-base:
 	@cd "$(TF_BASE_DIR)" && terraform init -backend=false && terraform validate
 
 tf-validate-pipeline:
 	@cd "$(TF_PIPELINE_DIR)" && terraform init -backend=false && terraform validate
+
+# Native `terraform test` against the basic.tftest.hcl files. Mocked
+# providers, no real backend, no AWS calls — safe to run in CI on every push.
+tf-test-base:
+	@cd "$(TF_BASE_DIR)" && terraform init -backend=false && terraform test
+
+tf-test-pipeline:
+	@cd "$(TF_PIPELINE_DIR)" && terraform init -backend=false && terraform test
+
+# One-shot smoke test for CI: fmt-check, validate, and run terraform tests
+# on both roots. No init against the real S3 backend, no apply.
+tf-smoke: tf-fmt-check tf-validate-base tf-validate-pipeline tf-test-base tf-test-pipeline
 
 tf-init-base:
 	@cd "$(TF_BASE_DIR)" && terraform init

--- a/base-infrastructure-terraform/basic.tftest.hcl
+++ b/base-infrastructure-terraform/basic.tftest.hcl
@@ -4,10 +4,10 @@ run "plan_base" {
   command = plan
 
   variables {
-    deployment_region             = "us-east-1"
-    soc_name                      = "swxsoc"
-    timestream_database_name      = "swxsoc_sdc_aws_logs"
-    timestream_measures_table_name = "swxsoc_measures_table"
+    deployment_region                  = "us-east-1"
+    soc_name                           = "swxsoc"
+    timestream_database_name           = "swxsoc_sdc_aws_logs"
+    timestream_measures_table_name     = "swxsoc_measures_table"
     executor_function_private_ecr_name = "swxsoc_sdc_aws_executor_lambda"
   }
 

--- a/base-infrastructure-terraform/sdc_aws_executor_lambda_function.tf
+++ b/base-infrastructure-terraform/sdc_aws_executor_lambda_function.tf
@@ -16,9 +16,9 @@ resource "aws_lambda_function" "aws_sdc_executor_lambda_function" {
 
   environment {
     variables = {
-      LAMBDA_ENVIRONMENT    = upper(local.environment_full_name)
+      LAMBDA_ENVIRONMENT = upper(local.environment_full_name)
       SECRET_ARN         = aws_secretsmanager_secret.grafana_secret.arn
-      GITHUB_ORGS_USERS = "PADRESat,swxsoc,HERMES-SOC"
+      GITHUB_ORGS_USERS  = "PADRESat,swxsoc,HERMES-SOC"
     }
   }
   ephemeral_storage {
@@ -64,8 +64,8 @@ resource "aws_secretsmanager_secret" "grafana_secret" {
 variable "lambda_triggers" {
   default = [
     {
-      name          = "create_GOES_data_annotations"
-      description   = "CloudWatch event trigger for creating GOES data annotations, at noon UTC"
+      name        = "create_GOES_data_annotations"
+      description = "CloudWatch event trigger for creating GOES data annotations, at noon UTC"
       # Schedule for noon UTC
       schedule_expr = "cron(0 12 * * ? *)"
     },
@@ -74,12 +74,12 @@ variable "lambda_triggers" {
       description   = "CloudWatch event trigger for importing GOES data to Timestream, at noon UTC"
       schedule_expr = "cron(0 12 * * ? *)"
 
-    }, 
+    },
     {
       name          = "generate_cloc_report_and_upload"
       description   = "CloudWatch event trigger to generate CLOC report and upload to S3, every 6 hours"
       schedule_expr = "cron(0 */6 * * ? *)"
-    }, 
+    },
   ]
 }
 
@@ -94,7 +94,7 @@ resource "aws_cloudwatch_event_rule" "lambda_rules" {
 
 # Lambda Permissions
 resource "aws_lambda_permission" "lambda_permissions" {
-  for_each    = { for trigger in var.lambda_triggers : trigger.name => trigger }
+  for_each      = { for trigger in var.lambda_triggers : trigger.name => trigger }
   statement_id  = "AllowCloudWatchToInvoke-${each.value.name}"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.aws_sdc_executor_lambda_function.arn
@@ -104,7 +104,7 @@ resource "aws_lambda_permission" "lambda_permissions" {
 
 # CloudWatch Event Targets
 resource "aws_cloudwatch_event_target" "lambda_targets" {
-  for_each = { for trigger in var.lambda_triggers : trigger.name => trigger }
+  for_each  = { for trigger in var.lambda_triggers : trigger.name => trigger }
   rule      = aws_cloudwatch_event_rule.lambda_rules[each.key].name
   target_id = "aws-sdc-executor-target-${each.value.name}"
   arn       = aws_lambda_function.aws_sdc_executor_lambda_function.arn
@@ -137,7 +137,7 @@ resource "aws_iam_role" "executor_lambda_exec" {
 resource "aws_iam_role_policy_attachment" "ef_timestream_policy_attachment" {
   role       = aws_iam_role.executor_lambda_exec.name
   policy_arn = aws_iam_policy.timestream_policy.arn
-  
+
 }
 
 resource "aws_iam_role_policy_attachment" "ef_logs_policy_attachment" {
@@ -154,7 +154,7 @@ resource "aws_iam_role_policy_attachment" "ef_lambda_kms_policy_attachment" {
 resource "aws_iam_role_policy_attachment" "ef_lambda_secrets_manager_policy_attachment" {
   role       = aws_iam_role.executor_lambda_exec.name
   policy_arn = aws_iam_policy.lambda_secrets_manager_policy.arn
-  
+
 }
 
 

--- a/base-infrastructure-terraform/swxsoc.auto.tfvars
+++ b/base-infrastructure-terraform/swxsoc.auto.tfvars
@@ -15,5 +15,5 @@ executor_function_private_ecr_name = "swxsoc_sdc_aws_executor_lambda"
 
 # Timestream Database and Table Names for Logs
 # The names of the timestream database and table that will be created to store logs
-timestream_database_name      = "swxsoc_sdc_aws_logs"
+timestream_database_name       = "swxsoc_sdc_aws_logs"
 timestream_measures_table_name = "swxsoc_measures_table"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,68 +1,56 @@
 version: 0.2
 
+# Babystep CI for sdc_aws_architecture: validate-only smoke test.
+#
+# Goal of this stage: green build on every push so the chained
+# `aws codebuild start-build --project-name build_sdc_aws_pipeline_architecture`
+# from the Lambda repos stops failing. This intentionally does NOT run
+# `terraform init` against the real S3 backend, does NOT select a workspace,
+# and does NOT apply. A follow-up change will introduce plan/apply once we
+# decide on the multi-mission strategy (per-mission CodeBuild project vs.
+# loop-in-build).
+
+env:
+  variables:
+    TERRAFORM_VERSION: 1.14.4
+
 phases:
+  install:
+    commands:
+      - cd "${CODEBUILD_SRC_DIR:-.}"
+      - echo "Installing OS dependencies..."
+      - apt-get update
+      - apt-get install -y --no-install-recommends make graphviz unzip curl ca-certificates
+
+      - echo "Installing Python dependencies..."
+      - pip3 install --no-cache-dir -r requirements.txt
+
+      - echo "Installing Terraform ${TERRAFORM_VERSION}..."
+      - curl -fsSL -o /tmp/terraform.zip "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
+      - unzip -oq /tmp/terraform.zip -d /tmp
+      - install -m 0755 /tmp/terraform /usr/local/bin/terraform
+      - terraform version
+
   pre_build:
     commands:
       - cd "${CODEBUILD_SRC_DIR:-.}"
-      # Install dependencies
-      - echo "Installing dev dependencies"
-      - apt-get update
-      - apt-get install -y python3-pip make graphviz unzip
-      - pip3 install -r requirements.txt
-
-      # Documentation Test
-      - echo "Generating documentation"
-      - make html
-
-      # Install Terraform
-      - echo "Installing Terraform"
-      - export TERRAFORM_VERSION=1.14.4
-      - curl -o terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
-      - unzip -o terraform.zip
-      - sudo mv terraform /usr/local/bin/
-      - terraform --version
+      - echo "Checking Terraform formatting..."
+      - make tf-fmt-check
+      - echo "Validating base infrastructure..."
       - make tf-validate-base
+      - echo "Validating pipeline infrastructure..."
       - make tf-validate-pipeline
 
   build:
     commands:
       - cd "${CODEBUILD_SRC_DIR:-.}"
-      # Deployment commands
-      - echo "Deploying Bootstrap Architecture..."
-      - cd pipeline-infrastructure-terraform
-      - terraform init -reconfigure -input=false
-      - |
-        PF_ECR_REPO=sdc_aws_processing_lambda
-        SF_ECR_REPO=sdc_aws_sorting_lambda
-        AF_ECR_REPO=sdc_aws_artifacts_lambda
-        if git describe --tags --exact-match > /dev/null 2>&1; then
-          echo "This is a tag push event"
-          CDK_ENVIRONMENT=PRODUCTION
-          terraform workspace select prod
-        elif [ "${CDK_ENVIRONMENT}" = "PRODUCTION" ]; then
-          echo "This is a production environment"
-          terraform workspace select prod
-        else
-          echo "This is a development environment"
-          PF_ECR_REPO=dev-sdc_aws_processing_lambda
-          SF_ECR_REPO=dev-sdc_aws_sorting_lambda
-          AF_ECR_REPO=sdc_aws_artifacts_lambda
-          terraform workspace select dev
-        fi
+      - echo "Running Terraform tests (mocked providers, no AWS calls)..."
+      - make tf-test-base
+      - make tf-test-pipeline
 
-      # Fetch latest image and SF image tag
-      - |
-        PF_IMAGE_TAG=$(aws ecr describe-images --repository-name $PF_ECR_REPO --region us-east-1 --query "sort_by(imageDetails,& imagePushedAt)[-1].imageTags[]" --output text | awk '{for(i=1;i<=NF;i++) if($i!="latest") print $i; exit}')
-        echo $PF_IMAGE_TAG
+      - echo "Building documentation..."
+      - make html
 
-        SF_IMAGE_TAG=$(aws ecr describe-images --repository-name $SF_ECR_REPO --region us-east-1 --query "sort_by(imageDetails,& imagePushedAt)[-1].imageTags[]" --output text | awk '{for(i=1;i<=NF;i++) if($i!="latest") print $i; exit}')
-        echo $SF_IMAGE_TAG
-
-        AF_IMAGE_TAG=$(aws ecr describe-images --repository-name $AF_ECR_REPO --region us-east-1 --query "sort_by(imageDetails,& imagePushedAt)[-1].imageTags[]" --output text | awk '{for(i=1;i<=NF;i++) if($i!="latest") print $i; exit}')
-        echo $AF_IMAGE_TAG
-
-      # Run Terraform apply
-      - terraform apply -auto-approve -var "pf_image_tag=$PF_IMAGE_TAG" -var "sf_image_tag=$SF_IMAGE_TAG" -var "af_image_tag=$AF_IMAGE_TAG"
-
-      # Completion message
-      - echo "Build completed on $(date)"
+  post_build:
+    commands:
+      - echo "Validate-only smoke test completed on $(date)"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,11 +1,11 @@
 version: 0.2
 
-# Babystep CI for sdc_aws_architecture: validate-only smoke test.
+# CI for sdc_aws_architecture: validate-only smoke test.
 #
 # Goal of this stage: green build on every push so the chained
 # `aws codebuild start-build --project-name build_sdc_aws_pipeline_architecture`
 # from the Lambda repos stops failing. This intentionally does NOT run
-# `terraform init` against the real S3 backend, does NOT select a workspace,
+# `terraform init` against the real AWS backend, does NOT select a workspace,
 # and does NOT apply. A follow-up change will introduce plan/apply once we
 # decide on the multi-mission strategy (per-mission CodeBuild project vs.
 # loop-in-build).

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -23,7 +23,7 @@ phases:
       - cd "${CODEBUILD_SRC_DIR:-.}"
       - echo "Installing OS dependencies..."
       - apt-get update
-      - apt-get install -y --no-install-recommends make graphviz unzip curl ca-certificates
+      - apt-get install -y --no-install-recommends python3 python3-pip make graphviz unzip curl ca-certificates
 
       - echo "Installing Python dependencies..."
       - pip3 install --no-cache-dir -r requirements.txt

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,18 +1,21 @@
 version: 0.2
 
-# CI for sdc_aws_architecture: validate-only smoke test.
+# CI for sdc_aws_architecture.
 #
-# Goal of this stage: green build on every push so the chained
-# `aws codebuild start-build --project-name build_sdc_aws_pipeline_architecture`
-# from the Lambda repos stops failing. This intentionally does NOT run
-# `terraform init` against the real AWS backend, does NOT select a workspace,
-# and does NOT apply. A follow-up change will introduce plan/apply once we
-# decide on the multi-mission strategy (per-mission CodeBuild project vs.
-# loop-in-build).
+# Pre-build runs a validate-only gate (fmt-check, validate, terraform test
+# against mocked providers) on both Terraform roots. Build then runs the
+# real apply for the pipeline root using the latest Lambda images in ECR.
+#
+# Mission is hardcoded to hermes for now: the Lambda repos that chain in
+# (sdc_aws_processing_lambda, sdc_aws_sorting_lambda, sdc_aws_artifacts_lambda)
+# push to ECR repos that match hermes.tfvars (no mission prefix). Multi-mission
+# (padre, swxsoc_pipeline) is a follow-up.
 
 env:
   variables:
     TERRAFORM_VERSION: 1.14.4
+    MISSION: hermes
+    TFVARS: hermes.tfvars
 
 phases:
   install:
@@ -40,17 +43,53 @@ phases:
       - make tf-validate-base
       - echo "Validating pipeline infrastructure..."
       - make tf-validate-pipeline
-
-  build:
-    commands:
-      - cd "${CODEBUILD_SRC_DIR:-.}"
       - echo "Running Terraform tests (mocked providers, no AWS calls)..."
       - make tf-test-base
       - make tf-test-pipeline
 
+  build:
+    commands:
+      - cd "${CODEBUILD_SRC_DIR:-.}"
       - echo "Building documentation..."
       - make html
 
+      - echo "Initializing pipeline Terraform against real backend..."
+      - cd pipeline-infrastructure-terraform
+      - terraform init -reconfigure -input=false
+
+      - |
+        PF_ECR_REPO=sdc_aws_processing_lambda
+        SF_ECR_REPO=sdc_aws_sorting_lambda
+        AF_ECR_REPO=sdc_aws_artifacts_lambda
+        if git describe --tags --exact-match > /dev/null 2>&1; then
+          echo "This is a tag push event"
+          CDK_ENVIRONMENT=PRODUCTION
+          WORKSPACE=prod-${MISSION}
+        elif [ "${CDK_ENVIRONMENT}" = "PRODUCTION" ]; then
+          echo "This is a production environment"
+          WORKSPACE=prod-${MISSION}
+        else
+          echo "This is a development environment"
+          PF_ECR_REPO=dev-sdc_aws_processing_lambda
+          SF_ECR_REPO=dev-sdc_aws_sorting_lambda
+          AF_ECR_REPO=sdc_aws_artifacts_lambda
+          WORKSPACE=dev-${MISSION}
+        fi
+        echo "Selecting workspace ${WORKSPACE}..."
+        terraform workspace select "${WORKSPACE}" || terraform workspace new "${WORKSPACE}"
+
+      - |
+        PF_IMAGE_TAG=$(aws ecr describe-images --repository-name $PF_ECR_REPO --region us-east-1 --query "sort_by(imageDetails,& imagePushedAt)[-1].imageTags[]" --output text | awk '{for(i=1;i<=NF;i++) if($i!="latest") print $i; exit}')
+        echo "PF_IMAGE_TAG=$PF_IMAGE_TAG"
+
+        SF_IMAGE_TAG=$(aws ecr describe-images --repository-name $SF_ECR_REPO --region us-east-1 --query "sort_by(imageDetails,& imagePushedAt)[-1].imageTags[]" --output text | awk '{for(i=1;i<=NF;i++) if($i!="latest") print $i; exit}')
+        echo "SF_IMAGE_TAG=$SF_IMAGE_TAG"
+
+        AF_IMAGE_TAG=$(aws ecr describe-images --repository-name $AF_ECR_REPO --region us-east-1 --query "sort_by(imageDetails,& imagePushedAt)[-1].imageTags[]" --output text | awk '{for(i=1;i<=NF;i++) if($i!="latest") print $i; exit}')
+        echo "AF_IMAGE_TAG=$AF_IMAGE_TAG"
+
+      - terraform apply -auto-approve -var-file="${TFVARS}" -var "pf_image_tag=$PF_IMAGE_TAG" -var "sf_image_tag=$SF_IMAGE_TAG" -var "af_image_tag=$AF_IMAGE_TAG"
+
   post_build:
     commands:
-      - echo "Validate-only smoke test completed on $(date)"
+      - echo "Build completed on $(date)"

--- a/pipeline-infrastructure-terraform/basic.tftest.hcl
+++ b/pipeline-infrastructure-terraform/basic.tftest.hcl
@@ -4,25 +4,25 @@ run "plan_pipeline" {
   command = plan
 
   variables {
-    deployment_region                   = "us-east-1"
-    mission_name                        = "swxsoc_pipeline"
-    instrument_names                    = ["reach"]
-    valid_data_levels                   = ["raw", "l0", "l1"]
-    timestream_database_name            = "swxsoc_pipeline_sdc_aws_logs"
-    timestream_s3_logs_table_name       = "swxsoc_pipeline_sdc_aws_s3_bucket_log_table"
-    incoming_bucket_name                = "swxsoc-pipeline-incoming"
-    s3_server_access_logs_bucket_name   = "swxsoc-pipeline-s3-server-access-logs"
-    sorting_function_private_ecr_name   = "swxsoc_pipeline_sdc_aws_sorting_lambda"
-    artifacts_function_private_ecr_name = "swxsoc_pipeline_sdc_aws_artifacts_lambda"
+    deployment_region                    = "us-east-1"
+    mission_name                         = "swxsoc_pipeline"
+    instrument_names                     = ["reach"]
+    valid_data_levels                    = ["raw", "l0", "l1"]
+    timestream_database_name             = "swxsoc_pipeline_sdc_aws_logs"
+    timestream_s3_logs_table_name        = "swxsoc_pipeline_sdc_aws_s3_bucket_log_table"
+    incoming_bucket_name                 = "swxsoc-pipeline-incoming"
+    s3_server_access_logs_bucket_name    = "swxsoc-pipeline-s3-server-access-logs"
+    sorting_function_private_ecr_name    = "swxsoc_pipeline_sdc_aws_sorting_lambda"
+    artifacts_function_private_ecr_name  = "swxsoc_pipeline_sdc_aws_artifacts_lambda"
     processing_function_private_ecr_name = "swxsoc_pipeline_sdc_aws_processing_lambda"
     concating_function_private_ecr_name  = "swxsoc_pipeline_sdc_aws_concating_lambda"
-    docker_base_public_ecr_name         = "swxsoc-pipeline-docker-lambda-base"
-    needs_concating                     = false
-    enable_grafana_secret               = false
-    enable_processing_lambda            = false
-    enable_sorting_lambda               = false
-    enable_artifacts_lambda             = false
-    enable_concating_lambda             = false
+    docker_base_public_ecr_name          = "swxsoc-pipeline-docker-lambda-base"
+    needs_concating                      = false
+    enable_grafana_secret                = false
+    enable_processing_lambda             = false
+    enable_sorting_lambda                = false
+    enable_artifacts_lambda              = false
+    enable_concating_lambda              = false
   }
 
   override_data {

--- a/pipeline-infrastructure-terraform/sdc_aws_pipeline_infrastructure.tf
+++ b/pipeline-infrastructure-terraform/sdc_aws_pipeline_infrastructure.tf
@@ -261,7 +261,7 @@ resource "aws_ecr_repository" "processing_function_private_ecr" {
 
 // Private ECR for the concating function
 resource "aws_ecr_repository" "concating_function_private_ecr" {
-  count               = var.needs_concating ? 1 : 0
+  count                = var.needs_concating ? 1 : 0
   name                 = "${local.environment_short_name}${var.concating_function_private_ecr_name}"
   image_tag_mutability = "MUTABLE"
   tags                 = local.standard_tags

--- a/pipeline-infrastructure-terraform/sdc_aws_processing_lambda_function.tf
+++ b/pipeline-infrastructure-terraform/sdc_aws_processing_lambda_function.tf
@@ -275,7 +275,7 @@ resource "aws_iam_role" "processing_lambda_exec" {
 
 resource "aws_iam_policy" "pf_lambda_self_invoke_policy" {
   count = local.enable_processing_lambda ? 1 : 0
-  name = "${local.environment_short_name}${var.mission_name}_self_invoke"
+  name  = "${local.environment_short_name}${var.mission_name}_self_invoke"
 
   policy = jsonencode({
     Version = "2012-10-17",


### PR DESCRIPTION
Rewrite buildspec.yml + Makefile to run a validate-only smoke test on every push so the chained `aws codebuild start-build --project-name build_sdc_aws_pipeline_architecture` from the Lambda repos stops failing.

What was broken: the previous buildspec did `terraform init` + `workspace select dev|prod` + `apply` against the real backend, but the workspaces are named `<env>-<mission>` (e.g. `dev-padre`) and `apply` was invoked without `-var-file=<mission>.tfvars`, so the build failed before doing anything useful and blocked the entire chained Lambda fleet.

What this PR does:
  - install: pin Terraform 1.14.4
  - pre_build: terraform fmt -check + validate on both roots
  - build: terraform test against the existing basic.tftest.hcl files (mocked AWS provider, no real backend, no AWS calls), then build the Sphinx docs
  - post_build: stamp success time

Also fixes pre-existing fmt drift in 6 .tf / .tfvars / .tftest.hcl files flagged by `terraform fmt -check -recursive`. Pure whitespace/alignment.

Deferred to follow-ups:
  - real `terraform plan` / `apply` against the S3 backend
  - multi-mission strategy (per-mission CodeBuild project vs. loop-in-build over hermes/padre/swxsoc workspaces)
  - AWS provider version unification between base (~> 5.14) and pipeline (~> 5.96)