### PR TITLE
Enable swxsoc_pipeline artifacts Lambda deployment and add Terraform coverage

### DIFF
--- a/pipeline-infrastructure-terraform/basic.tftest.hcl
+++ b/pipeline-infrastructure-terraform/basic.tftest.hcl
@@ -49,3 +49,54 @@ run "plan_pipeline" {
     error_message = "Instrument bucket name should use hyphenated mission prefix."
   }
 }
+
+run "plan_swxsoc_artifacts_lambda" {
+  command = plan
+
+  variables {
+    deployment_region                    = "us-east-1"
+    mission_name                         = "swxsoc_pipeline"
+    instrument_names                     = ["reach"]
+    valid_data_levels                    = ["raw", "l0", "l1"]
+    timestream_database_name             = "swxsoc_pipeline_sdc_aws_logs"
+    timestream_s3_logs_table_name        = "swxsoc_pipeline_sdc_aws_s3_bucket_log_table"
+    incoming_bucket_name                 = "swxsoc-pipeline-incoming"
+    s3_server_access_logs_bucket_name    = "swxsoc-pipeline-s3-server-access-logs"
+    sorting_function_private_ecr_name    = "swxsoc_pipeline_sdc_aws_sorting_lambda"
+    artifacts_function_private_ecr_name  = "swxsoc_pipeline_sdc_aws_artifacts_lambda"
+    processing_function_private_ecr_name = "swxsoc_pipeline_sdc_aws_processing_lambda"
+    concating_function_private_ecr_name  = "swxsoc_pipeline_sdc_aws_concating_lambda"
+    docker_base_public_ecr_name          = "swxsoc-pipeline-docker-lambda-base"
+    needs_concating                      = false
+    enable_grafana_secret                = false
+    enable_processing_lambda             = false
+    enable_sorting_lambda                = false
+    enable_artifacts_lambda              = true
+    enable_concating_lambda              = false
+    artifacts_image_uri_override         = ""
+  }
+
+  override_data {
+    target = data.aws_vpc.default
+    values = {
+      id = "vpc-123456"
+    }
+  }
+
+  override_data {
+    target = data.aws_caller_identity.current
+    values = {
+      account_id = "123456789012"
+    }
+  }
+
+  assert {
+    condition     = length(resource.aws_lambda_function.aws_sdc_artifacts_lambda_function) == 1
+    error_message = "Artifacts Lambda should be planned when enable_artifacts_lambda is true."
+  }
+
+  assert {
+    condition     = length(resource.aws_sns_topic_subscription.af_sns_topic_subscription) == 1
+    error_message = "Artifacts Lambda should subscribe to each instrument SNS topic."
+  }
+}

--- a/pipeline-infrastructure-terraform/swxsoc_pipeline.tfvars
+++ b/pipeline-infrastructure-terraform/swxsoc_pipeline.tfvars
@@ -65,7 +65,7 @@ grafana_secret_name   = "swxsoc-pipeline-grafana-credentials"
 # Lambda creation flags (enable once images exist)
 enable_processing_lambda = true
 enable_sorting_lambda    = true
-enable_artifacts_lambda  = false
+enable_artifacts_lambda  = true
 enable_concating_lambda  = false
 
 # Lambda VPC settings (match existing default subnets; update if needed)
@@ -78,8 +78,8 @@ rds_ingress_cidr_blocks           = []
 # RDS engine version (must exist in target region)
 rds_engine_version = "14.21"
 
-# Use the mission ECR repositories and the default `latest` tags.
+# Use mission ECR repositories and the default `latest` tags for enabled Lambdas.
 processing_image_uri_override = ""
 sorting_image_uri_override    = ""
-artifacts_image_uri_override  = "public.ecr.aws/lambda/python:3.12"
+artifacts_image_uri_override  = ""
 concating_image_uri_override  = "public.ecr.aws/lambda/python:3.12"


### PR DESCRIPTION
This pull request adds a new test for the artifacts Lambda function and updates configuration to enable the artifacts Lambda in the SWXSOC pipeline. The changes ensure that the artifacts Lambda is included in the Terraform plan and that its image URI is no longer overridden by a public image.

**Artifacts Lambda Enablement and Testing:**

* Added a new test block `plan_swxsoc_artifacts_lambda` in `basic.tftest.hcl` to verify that the artifacts Lambda is planned and subscribes to the correct SNS topic when enabled.
* Changed `enable_artifacts_lambda` to `true` in `swxsoc_pipeline.tfvars`, enabling deployment of the artifacts Lambda.
* Removed the public image override for `artifacts_image_uri_override` in `swxsoc_pipeline.tfvars`, so the default image will be used for the artifacts Lambda.