### PR TITLE
Enhance infrastructure and testing for Impax and SWxSOC pipeline

### DIFF
--- a/base-infrastructure-terraform/basic.tftest.hcl
+++ b/base-infrastructure-terraform/basic.tftest.hcl
@@ -9,6 +9,7 @@ run "plan_base" {
     timestream_database_name           = "swxsoc_sdc_aws_logs"
     timestream_measures_table_name     = "swxsoc_measures_table"
     executor_function_private_ecr_name = "swxsoc_sdc_aws_executor_lambda"
+    s3_access_bucket_names             = ["dev-swxsoc-pipeline-incoming", "swxsoc-pipeline-incoming"]
   }
 
   override_data {
@@ -26,5 +27,10 @@ run "plan_base" {
   assert {
     condition     = resource.aws_security_group.lambda_sg.vpc_id == "vpc-123456"
     error_message = "Lambda SG should use the default VPC id."
+  }
+
+  assert {
+    condition     = resource.aws_iam_role_policy_attachment.ef_s3_access_policy_attachment[0].role == "swxsoc_executor_lambda_exec_role"
+    error_message = "Executor role should receive the configured S3 access policy."
   }
 }

--- a/base-infrastructure-terraform/sdc_aws_base_infrastructure.tf
+++ b/base-infrastructure-terraform/sdc_aws_base_infrastructure.tf
@@ -155,9 +155,16 @@ resource "aws_iam_policy" "lambda_vpc_access_policy" {
   })
 }
 
-# Policy to allow access to the S3 bucket swxsoc-github
+locals {
+  s3_access_bucket_names = toset(compact(concat(
+    var.s3_access_bucket_name != "" ? [var.s3_access_bucket_name] : [],
+    var.s3_access_bucket_names,
+  )))
+}
+
+# Policy to allow access to configured S3 buckets
 resource "aws_iam_policy" "s3_access_policy" {
-  count       = var.s3_access_bucket_name != "" ? 1 : 0
+  count       = length(local.s3_access_bucket_names) > 0 ? 1 : 0
   name        = "${local.environment_short_name}${var.soc_name}_s3_access_policy"
   description = "Custom policy for S3 access"
 
@@ -172,10 +179,10 @@ resource "aws_iam_policy" "s3_access_policy" {
           "s3:PutObject",
           "s3:DeleteObject"
         ],
-        Resource = [
-          "arn:aws:s3:::${var.s3_access_bucket_name}",
-          "arn:aws:s3:::${var.s3_access_bucket_name}/*"
-        ]
+        Resource = concat(
+          [for bucket_name in local.s3_access_bucket_names : "arn:aws:s3:::${bucket_name}"],
+          [for bucket_name in local.s3_access_bucket_names : "arn:aws:s3:::${bucket_name}/*"]
+        )
       }
     ]
   })

--- a/base-infrastructure-terraform/sdc_aws_base_infrastructure.tf
+++ b/base-infrastructure-terraform/sdc_aws_base_infrastructure.tf
@@ -156,10 +156,10 @@ resource "aws_iam_policy" "lambda_vpc_access_policy" {
 }
 
 locals {
-  s3_access_bucket_names = toset(compact(concat(
+  s3_access_bucket_names = sort(distinct(compact(concat(
     var.s3_access_bucket_name != "" ? [var.s3_access_bucket_name] : [],
     var.s3_access_bucket_names,
-  )))
+  ))))
 }
 
 # Policy to allow access to configured S3 buckets

--- a/base-infrastructure-terraform/sdc_aws_executor_lambda_function.tf
+++ b/base-infrastructure-terraform/sdc_aws_executor_lambda_function.tf
@@ -163,5 +163,11 @@ resource "aws_iam_role_policy_attachment" "ef_lambda_secrets_manager_policy_atta
 
 }
 
+resource "aws_iam_role_policy_attachment" "ef_s3_access_policy_attachment" {
+  count = length(local.s3_access_bucket_names) > 0 ? 1 : 0
+
+  role       = aws_iam_role.executor_lambda_exec.name
+  policy_arn = aws_iam_policy.s3_access_policy[0].arn
+}
 
 

--- a/base-infrastructure-terraform/swxsoc.auto.tfvars
+++ b/base-infrastructure-terraform/swxsoc.auto.tfvars
@@ -17,3 +17,10 @@ executor_function_private_ecr_name = "swxsoc_sdc_aws_executor_lambda"
 # The names of the timestream database and table that will be created to store logs
 timestream_database_name       = "swxsoc_sdc_aws_logs"
 timestream_measures_table_name = "swxsoc_measures_table"
+
+# Buckets where scheduled executor tasks upload generated artifacts.
+# REACH UDL ingest currently writes to both dev and prod incoming buckets.
+s3_access_bucket_names = [
+  "dev-swxsoc-pipeline-incoming",
+  "swxsoc-pipeline-incoming",
+]

--- a/base-infrastructure-terraform/variables.tf
+++ b/base-infrastructure-terraform/variables.tf
@@ -33,8 +33,14 @@ variable "ef_image_tag" {
 
 variable "s3_access_bucket_name" {
   type        = string
-  description = "Optional S3 bucket name to grant access to"
+  description = "Optional single S3 bucket name to grant access to"
   default     = ""
+}
+
+variable "s3_access_bucket_names" {
+  type        = list(string)
+  description = "Optional S3 bucket names to grant access to"
+  default     = []
 }
 
 variable "name" {

--- a/pipeline-infrastructure-terraform/hermes.tfvars
+++ b/pipeline-infrastructure-terraform/hermes.tfvars
@@ -44,3 +44,7 @@ processing_function_private_ecr_name = "sdc_aws_processing_lambda"
 # Docker Base ECR Repository Name
 # The name of the ECR repository that will be created to store the docker base image
 docker_base_public_ecr_name = "swsoc-docker-lambda-base"
+
+# RDS ingress allowlists
+rds_additional_security_group_ids = ["sg-002dbe7887ac759c5"] # Grafana EC2 webDMZ
+rds_ingress_cidr_blocks           = []

--- a/pipeline-infrastructure-terraform/impax.tfvars
+++ b/pipeline-infrastructure-terraform/impax.tfvars
@@ -76,7 +76,7 @@ enable_concating_lambda  = false
 lambda_vpc_subnet_ids = ["subnet-0972d4965ef8eb1e8", "subnet-0e24325c69b9a1f74"]
 
 # RDS ingress allowlists
-rds_additional_security_group_ids = []
+rds_additional_security_group_ids = ["sg-002dbe7887ac759c5"] # Grafana EC2 webDMZ
 rds_ingress_cidr_blocks           = []
 
 # RDS engine version (must exist in target region)

--- a/pipeline-infrastructure-terraform/padre.tfvars
+++ b/pipeline-infrastructure-terraform/padre.tfvars
@@ -57,3 +57,7 @@ docker_base_public_ecr_name = "padre-swsoc-docker-lambda-base"
 ## IAM Role for pushing to S3 Incoming Bucket
 # The name of the IAM role from the other account that will be used to push to the incoming bucket
 optional_s3_uploader_role_arn = "arn:aws:iam::815232357003:role/data-transfer-12321-padre"
+
+# RDS ingress allowlists
+rds_additional_security_group_ids = ["sg-002dbe7887ac759c5"] # Grafana EC2 webDMZ
+rds_ingress_cidr_blocks           = []

--- a/pipeline-infrastructure-terraform/swxsoc_pipeline.tfvars
+++ b/pipeline-infrastructure-terraform/swxsoc_pipeline.tfvars
@@ -71,8 +71,8 @@ enable_concating_lambda  = false
 # Lambda VPC settings (match existing default subnets; update if needed)
 lambda_vpc_subnet_ids = ["subnet-0972d4965ef8eb1e8", "subnet-0e24325c69b9a1f74"]
 
-# RDS ingress allowlists (empty for swxsoc_pipeline to avoid missing SG/CIDR)
-rds_additional_security_group_ids = []
+# RDS ingress allowlists
+rds_additional_security_group_ids = ["sg-002dbe7887ac759c5"] # Grafana EC2 webDMZ
 rds_ingress_cidr_blocks           = []
 
 # RDS engine version (must exist in target region)

--- a/pipeline-infrastructure-terraform/variables.tf
+++ b/pipeline-infrastructure-terraform/variables.tf
@@ -202,13 +202,13 @@ variable "lambda_vpc_subnet_ids" {
 variable "rds_additional_security_group_ids" {
   type        = list(string)
   description = "Additional security groups allowed to access RDS"
-  default     = ["sg-002dbe7887ac759c5"]
+  default     = []
 }
 
 variable "rds_ingress_cidr_blocks" {
   type        = list(string)
   description = "Additional CIDR blocks allowed to access RDS"
-  default     = ["86.21.42.229/32"]
+  default     = []
 }
 
 variable "rds_engine_version" {

--- a/pipeline-infrastructure-terraform/variables.tf
+++ b/pipeline-infrastructure-terraform/variables.tf
@@ -202,7 +202,7 @@ variable "lambda_vpc_subnet_ids" {
 variable "rds_additional_security_group_ids" {
   type        = list(string)
   description = "Additional security groups allowed to access RDS"
-  default     = []
+  default     = ["sg-002dbe7887ac759c5"]
 }
 
 variable "rds_ingress_cidr_blocks" {


### PR DESCRIPTION
This pull request introduces support for configuring access to multiple S3 buckets for the executor Lambda function and updates RDS security group defaults and allowlists for improved flexibility and clarity. The main changes involve new variables for specifying multiple S3 buckets, updates to IAM policies and attachments to support these, and adjustments to RDS security group settings.

**S3 Bucket Access Enhancements:**

* Added new variable `s3_access_bucket_names` (list of strings) to allow specifying multiple S3 buckets for Lambda access, and updated related documentation and test files (`variables.tf`, `swxsoc.auto.tfvars`, `basic.tftest.hcl`). [[1]](diffhunk://#diff-80e2ce555b5e02636d393ae18b6ea1b0a61f1d141e13d0ebc54588e1fc00fdffL36-R45) [[2]](diffhunk://#diff-5b1af87b02558a7dd08f7d3960570bdec768bfe9c5f6d99361cec28b9f5cabc8R20-R26) [[3]](diffhunk://#diff-41c049b57c5cc13623a6d98a223849fdd50faaf39130c6a14759bf840392a42aR12)
* Refactored IAM policy logic to grant access to all buckets listed in `s3_access_bucket_names`, and updated the resource attachment to apply the policy to the Lambda execution role. [[1]](diffhunk://#diff-f600b2e5d0a6ebb16e3b82c1c5c2c14e3e99ff1508f695668740f24473629c3cL158-R167) [[2]](diffhunk://#diff-f600b2e5d0a6ebb16e3b82c1c5c2c14e3e99ff1508f695668740f24473629c3cL175-R185) [[3]](diffhunk://#diff-c4fd7fe932faa0af25d67f91440cff97be3928fc2a75d947c303c0fa1b60fe16R166-R171)
* Added a test assertion to ensure the executor role is attached to the correct S3 access policy.

**RDS Security Group Configuration:**

* Changed the default for `rds_additional_security_group_ids` and `rds_ingress_cidr_blocks` variables to empty lists for improved configuration flexibility (`variables.tf`).
* Updated pipeline environment variable files to explicitly specify the Grafana EC2 webDMZ security group in `rds_additional_security_group_ids` for RDS access (`impax.tfvars`, `swxsoc_pipeline.tfvars`). [[1]](diffhunk://#diff-44b7eb3254e3dc2d86f2f91dbcab9b0525fa1d8355609281f212e175bee63b5eL79-R79) [[2]](diffhunk://#diff-6a0e6b44bc47a9afbc1cd3853ce9d8075f9853e6427bd06f5e7fc45ffe7e8c1fL74-R75)


more changes incoming in this PR...